### PR TITLE
Add support for relative paths

### DIFF
--- a/src/Cli/Convert.php
+++ b/src/Cli/Convert.php
@@ -34,9 +34,13 @@ class Convert extends Command
         $readme = $input->getOption('input') ?: $input->getArgument('input');
         if ($readme === null) {
             $readme = 'php://stdin';
-        } elseif (is_file($readme) === false || is_readable($readme) === false) {
-            $output->writeln('<error>You should specify a readable readme file</error>');
-            die();
+        } elseif (is_file($readme) === false) {
+            $readme = stream_resolve_include_path($readme);
+
+            if (is_file($readme) === false || is_readable($readme) === false) {
+                $output->writeln('<error>You should specify a readable readme file</error>');
+                die();
+            }
         }
 
         $readmeData = file_get_contents($readme);


### PR DESCRIPTION
Previously the command wasn't able to pickup relative paths. The following fails.
```bash
$ touch readme.txt
$ wp2md convert readme.txt README.md
You should specify a readable readme file
```

With this fix, it will correctly pickup the `readme.txt` relative file, as well as support absolute ones.