### PR TITLE
Add »Requires PHP« readme header to converter

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -35,6 +35,7 @@ class Converter
             'Tags',
             'Requires at least',
             'Tested up to',
+            'Requires PHP',
             'Stable tag',
             'License',
             'License URI',


### PR DESCRIPTION
Hi,

thanks for the script and CLI version! :)

There is a [new plugin header to specify the minimum PHP version a plugin needs
](https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/)– this PR adds it to the `Converter.php` :)

Regards,
Florian