### PR TITLE
Equal signs should not cause headings in general

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -46,9 +46,9 @@ final class Converter
         // Convert Headings
         // original code from https://github.com/markjaquith/WordPress-Plugin-Readme-Parser/blob/master/parse-readme.php
         // using here in reverse to go from WP to GitHub style headings
-        $readme = preg_replace('|\n*===\s*([^=]+?)\s*=*\s*\n+|im', PHP_EOL . "\n# $1\n" . PHP_EOL, $readme);
-        $readme = preg_replace('|\n*==\s*([^=]+?)\s*=*\s*\n+|im', PHP_EOL . "\n## $1\n" . PHP_EOL, $readme);
-        $readme = preg_replace('|\n*=\s*([^=]+?)\s*=*\s*\n+|im', PHP_EOL . "\n### $1\n" . PHP_EOL, $readme);
+        $readme = preg_replace('|\n===\s*([^=]+?)\s*=*\s*\n+|im', PHP_EOL . "\n# $1\n" . PHP_EOL, $readme);
+        $readme = preg_replace('|\n==\s*([^=]+?)\s*=*\s*\n+|im', PHP_EOL . "\n## $1\n" . PHP_EOL, $readme);
+        $readme = preg_replace('|\n=\s*([^=]+?)\s*=*\s*\n+|im', PHP_EOL . "\n### $1\n" . PHP_EOL, $readme);
 
         return $readme;
     }


### PR DESCRIPTION
fixes #28.

A heading should always start in a new line. the asterisk makes the line break optional.
